### PR TITLE
Documentation Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Luke Roberts <lukeroberts.j@gmail.com>"]
 description = """
-Derive associated functions for enum variants that are familiar from `std::option::Option` & `std::result::Result` such as `unwrap_or` or `and_then`.
+Derive helper methods for enum variants that are familiar from `std::option::Option` & `std::result::Result` such as `unwrap_or` or `and_then`.
 """
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Variantly
-Derive associated functions for enum variants that are familiar from `std::option::Option` & `std::result::Result` such as `unwrap_or` or `and_then`.
+Derive helper methods for enum variants that are familiar from `std::option::Option` & `std::result::Result` such as `unwrap_or` or `and_then`.
 # Example
 ```rust
 #[derive(Variantly)]
@@ -59,7 +59,7 @@ fn example() {
     let result_rgb = color.ok_or_else_rgb(|| Some("This is a computationally expensive error!"));
     assert!(result_rgb.is_err());
 
-    // The `#[variantly(rename = "darkness")]` attribute renames associated functions:
+    // The `#[variantly(rename = "darkness")]` attribute renames derived methods:
     let color = Color::Black;
     assert!(color.is_darkness())
 }
@@ -101,8 +101,8 @@ fn it_makes_a_name() {
 }
 ```
 
-# Renaming associated functions
-The `varianty` attribute may be placed on a variant in order to customize the resulting associated function names.
+# Renaming Methods
+The `varianty` attribute may be placed on a variant in order to customize the resulting method names.
 ```rust
 #[derive(Variantly)]
 enum SomeEnum {

--- a/README.md
+++ b/README.md
@@ -87,18 +87,15 @@ Simplified, this looks like:
 ```rust
 use inflector::cases::snakecase::to_snake_case;
 
-fn name_fn(operation: String, variant_name: String) -> String {
+fn name_fn(operation: &str, variant_name: &str) -> String {
     let snake_case_variant = to_snake_case(&variant_name);
-    format!("{}_{}", snake_case_variant, operation)
+    format!("{}_{}", operation, snake_case_variant)
 }
 
-#[test]
-fn it_makes_a_name() {
-    assert_eq!(
-        name_fn("unwrap","VariantA"),
-        "unwrap_variant_a".into()
-    )
-}
+assert_eq!(
+    name_fn("unwrap","VariantA"),
+    String::from("unwrap_variant_a")
+)
 ```
 
 # Renaming Methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,12 @@
 //! Simplified, this looks like:
 //! ```
 //! use inflector::cases::snakecase::to_snake_case;
-//! 
+//!
 //! fn name_fn(operation: &str, variant_name: &str) -> String {
 //!     let snake_case_variant = to_snake_case(&variant_name);
 //!     format!("{}_{}", operation, snake_case_variant)
 //! }
-//! 
+//!
 //! assert_eq!(
 //!     name_fn("unwrap","VariantA"),
 //!     String::from("unwrap_variant_a")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,19 +85,16 @@
 //! Simplified, this looks like:
 //! ```
 //! use inflector::cases::snakecase::to_snake_case;
-//!
-//! fn name_fn(operation: String, variant_name: String) -> String {
+//! 
+//! fn name_fn(operation: &str, variant_name: &str) -> String {
 //!     let snake_case_variant = to_snake_case(&variant_name);
-//!     format!("{}_{}", snake_case_variant, operation)
+//!     format!("{}_{}", operation, snake_case_variant)
 //! }
-//!
-//! #[test]
-//!fn it_makes_a_name() {
-//!     assert_eq!(
-//!         name_fn("unwrap","VariantA"),
-//!         "unwrap_variant_a".into()
-//!     )
-//! }
+//! 
+//! assert_eq!(
+//!     name_fn("unwrap","VariantA"),
+//!     String::from("unwrap_variant_a")
+//! )
 //! ```
 //!
 //! # Renaming Methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Derive associated functions for enum variants that are familiar from `std::option::Option` & `std::result::Result` such as `unwrap_or` or `and_then`.
+//! Derive helper methods for enum variants that are familiar from `std::option::Option` & `std::result::Result` such as `unwrap_or` or `and_then`.
 //! # Example
 //! ```ignore, no_run
 //! #[derive(Variantly)]
@@ -58,7 +58,7 @@
 //!     let result_rgb = color.ok_or_else_rgb(|| Some("This is a computationally expensive error!"));
 //!     assert!(result_rgb.is_err());
 //!
-//!     // The `#[variantly(rename = "darkness")]` attribute renames associated functions:
+//!     // The `#[variantly(rename = "darkness")]` attribute renames methods.
 //!     let color = Color::Black;
 //!     assert!(color.is_darkness())
 //! }
@@ -100,8 +100,8 @@
 //! }
 //! ```
 //!
-//! # Renaming associated functions
-//! The `varianty` attribute may be placed on a variant in order to customize the resulting associated function names.
+//! # Renaming Methods
+//! The `varianty` attribute may be placed on a variant in order to customize the resulting method names.
 //! ```ignore, no_run
 //! #[derive(Variantly)]
 //! enum SomeEnum {

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -59,7 +59,7 @@ fn example() {
     let result_rgb = color.ok_or_else_rgb(|| Some("This is a computationally expensive error!"));
     assert!(result_rgb.is_err());
 
-    // The `#[variantly(rename = "darkness")]` attribute renames associated functions:
+    // The `#[variantly(rename = "darkness")]` attribute renames methods.
     let color = Color::Black;
     assert!(color.is_darkness())
 }


### PR DESCRIPTION
Closes https://github.com/luker-os/variantly/issues/2, fixing a few issues with the naming function example in the README and lib documentation.

Additionally, this changes the use of `associated function` to `method` in documentation. All derived functions take `self` as their first parameter, [and so they are methods](https://doc.rust-lang.org/reference/items/associated-items.html#methods).

