### PR TITLE
Add `ref_or` and `ref_of_else` functions

### DIFF
--- a/tests/derived_ok_ref_or.rs
+++ b/tests/derived_ok_ref_or.rs
@@ -1,0 +1,25 @@
+mod helper;
+use helper::{
+    TestEnum,
+    TestEnum::{Int, Unit},
+};
+#[test]
+fn single_value_tuple() {
+    // Match
+    assert_eq!(Int(123).int_ref_or("ERR").unwrap(), &123);
+
+    // Non-Match
+    assert_eq!(Unit.int_ref_or("ERR").unwrap_err(), "ERR");
+}
+
+#[test]
+fn multi_value_tuple() {
+    // Match
+    assert_eq!(
+        TestEnum::new_tuple(123).tuple_ref_or("ERR").unwrap(),
+        (&"123".into(), &123)
+    );
+
+    // Non-Match
+    assert_eq!(Unit.tuple_ref_or("ERR").unwrap_err(), "ERR");
+}

--- a/tests/derived_ok_ref_or_else.rs
+++ b/tests/derived_ok_ref_or_else.rs
@@ -1,0 +1,28 @@
+mod helper;
+use helper::{
+    TestEnum,
+    TestEnum::{Int, Unit},
+};
+
+#[test]
+fn single_value_tuple() {
+    // Match
+    assert_eq!(Int(123).int_ref_or_else(|| "ERR").unwrap(), &123);
+
+    // Non-Match
+    assert_eq!(Unit.int_ref_or_else(|| "ERR").unwrap_err(), "ERR");
+}
+
+#[test]
+fn multi_value_tuple() {
+    // Match
+    assert_eq!(
+        TestEnum::new_tuple(123)
+            .tuple_ref_or_else(|| "ERR")
+            .unwrap(),
+        (&"123".into(), &123)
+    );
+
+    // Non-Match
+    assert_eq!(Unit.tuple_ref_or_else(|| "ERR").unwrap_err(), "ERR");
+}


### PR DESCRIPTION
This merge requests implements two functions to get a variant as a reference :
- `pub fn {variant_name}_ref_or<E>(&self, err: E) -> Result<(...), E>`
- `pub fn {variant_name}_ref_or_else<E, F: FnOnce() -> E>(&self, f: F) -> Result<(...), E>`

My use case for needing and implementing this is that I receive a reference from a vector of enum and I want to simply match with a specific struct variant and peek into one of its fields.