### PR TITLE
Add `_ref()` method and documentation for all `ref` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Derived methods for obtaining references to inner values:
+   - - `.{variant_name}_ref()`
+   - - `.{variant_name}_ref_or()`
+   - - `.{variant_name}_ref_or_else()`
 
 ## [0.2.0] - 2021-01-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  - Derived methods for obtaining references to inner values:
-   - - `.{variant_name}_ref()`
-   - - `.{variant_name}_ref_or()`
-   - - `.{variant_name}_ref_or_else()`
+   - `.{variant_name}_ref()`
+   - `.{variant_name}_ref_or()`
+   - `.{variant_name}_ref_or_else()`
 
 ## [0.2.0] - 2021-01-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ assert_eq!(None, color.rgb());
 
 *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
 
+### `pub fn {variant_name}_ref(&self) -> Option(&...)`
+If the enum is of the given variant, returns a `Some` containing a ref to the inner variant value. Otherwise, return None.
+
+#### Example
+```rust
+let color = Color::HSV(1,2,3);
+
+let option = color.hsv_ref();
+assert_eq!(Some((&1, &2, &3)), option);
+
+let color = Color::FromOutOfSpace;
+assert_eq!(None, color.rgb_ref());
+```
+
+*Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
+
 ### `pub fn {variant_name}_or<E>(self, err: E) -> Result<(...), E>`
 If the enum is of the given variant, returns a `Result::Ok` containing the inner value. Otherwise, return `Result::Err` containing `err`.
 
@@ -103,6 +119,23 @@ assert_eq!(Err("Error: Not an HSV!"), result);
 
 *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
 
+### `pub fn {variant_name}_ref_or<E>(&self, err: E) -> Result<(&...), E>`
+If the enum is of the given variant, returns a `Result::Ok` containing a ref to the inner value. Otherwise, return `Result::Err` containing `err`.
+
+#### Example
+```rust
+let color = Color::HSV(1,2,3);
+
+let result = color.hsv_ref_or("Error: Not an HSV!");
+assert_eq!(Ok((&1, &2, &3)), result);
+
+let color = Color::FromOutOfSpace;
+let result = color.hsv_ref_or("Error: Not an HSV!");
+assert_eq!(Err("Error: Not an HSV!"), result);
+```
+
+*Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
+
 ### `pub fn {variant_name}_or_else<E, F: FnOnce() -> E>(self, f: F) -> Result<(...), E>`
 If the enum is of the given variant, returns a `Result::Ok` containing the inner variant value. Otherwise, calls `f` to calculate a `Result::Err`.
 
@@ -115,6 +148,23 @@ assert_eq!(Ok((1, 2, 3)), result);
 
 let color = Color::FromOutOfSpace;
 let result = color.hsv_or_else(|| "This is an expensive error to create.");
+assert_eq!(Err("This is an expensive error to create."), result);
+```
+
+*Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
+
+### `pub fn {variant_name}_ref_or_else<E, F: FnOnce() -> E>(&self, f: F) -> Result<(&...), E>`
+If the enum is of the given variant, returns a `Result::Ok` containing a ref to the inner variant value. Otherwise, calls `f` to calculate a `Result::Err`.
+
+#### Example
+```rust
+let color = Color::HSV(1,2,3);
+
+let result = color.hsv_ref_or_else(|| "This is an expensive error to create.");
+assert_eq!(Ok((&1, &2, &3)), result);
+
+let color = Color::FromOutOfSpace;
+let result = color.hsv_ref_or_else(|| "This is an expensive error to create.");
 assert_eq!(Err("This is an expensive error to create."), result);
 ```
 
@@ -322,7 +372,7 @@ enum SomeEnum {
 }
 ```
 Without the `rename` attribute in the above, both variants would create conflicting functions such as `.is_abc()` due to the coercion to snake_case.
-This is avoided by using the rename input to create meaningful and unique fn names.
+This is avoided by using the `rename` input to create meaningful and unique fn names.
 
 #### License
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -130,6 +130,7 @@ fn handle_tuple(variant: &VariantParsed, functions: &mut Vec<TokenStream2>, enum
     };
 
     let var_fn = &variant.used_name;
+    let var_ref_fn = format_ident!("{}_ref", var_fn);
     let var_or_fn = format_ident!("{}_or", var_fn);
     let var_ref_or_fn = format_ident!("{}_ref_or", var_fn);
     let var_or_else_fn = format_ident!("{}_or_else", var_fn);
@@ -142,6 +143,13 @@ fn handle_tuple(variant: &VariantParsed, functions: &mut Vec<TokenStream2>, enum
     // Create and push actual impl functions
     functions.push(quote! {
         pub fn #var_fn(self) -> Option<(#types)> {
+            match self {
+                #var_pattern => Some((#vars)),
+                _ => None,
+            }
+        }
+
+        pub fn #var_ref_fn(&self) -> Option<(#ref_types)> {
             match self {
                 #var_pattern => Some((#vars)),
                 _ => None,

--- a/src/idents.rs
+++ b/src/idents.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 /// Declare a series of vars named by `operation` that contain an ident created
 /// by concatenating the stringified `operation`, and the passed in `ident`.
 /// # Examples
-/// ```
+/// ```ignore
+/// # use quote::format_ident;
 /// let foo = format_ident!("{}", "foo");
 /// identify!(foo, [get, and]);
 /// // Expands to:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,32 @@
 //!
 //! *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
 //!
+//! ### `pub fn {variant_name}_ref(&self) -> Option(&...)`
+//! If the enum is of the given variant, returns a `Some` containing a ref to the inner variant value. Otherwise, return None.
+//!
+//! #### Example
+//! ```
+//! # #[derive(variantly::Variantly, Debug, PartialEq)]
+//! # enum Color {
+//! #     RGB(u8, u8, u8),
+//! #     HSV(u8, u8, u8),
+//! #     Grey(u8),
+//! #     FromOutOfSpace,
+//! #     #[variantly(rename = "darkness")]
+//! #     Black,
+//! # }
+//!
+//! let color = Color::HSV(1,2,3);
+//!
+//! let option = color.hsv_ref();
+//! assert_eq!(Some((&1, &2, &3)), option);
+//!
+//! let color = Color::FromOutOfSpace;
+//! assert_eq!(None, color.rgb_ref());
+//! ```
+//!
+//! *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
+//!
 //! ### `pub fn {variant_name}_or<E>(self, err: E) -> Result<(...), E>`
 //! If the enum is of the given variant, returns a [`Result::Ok`] containing the inner value. Otherwise, return [`Result::Err`] containing `err`.
 //!
@@ -121,6 +147,32 @@
 //!
 //! *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
 //!
+//! ### `pub fn {variant_name}_ref_or<E>(&self, err: E) -> Result<(&...), E>`
+//! If the enum is of the given variant, returns a `Result::Ok` containing a ref to the inner value. Otherwise, return `Result::Err` containing `err`.
+//!
+//! #### Example
+//! ```
+//! # #[derive(variantly::Variantly, Debug, PartialEq)]
+//! # enum Color {
+//! #     RGB(u8, u8, u8),
+//! #     HSV(u8, u8, u8),
+//! #     Grey(u8),
+//! #     FromOutOfSpace,
+//! #     #[variantly(rename = "darkness")]
+//! #     Black,
+//! # }
+//! let color = Color::HSV(1,2,3);
+//!
+//! let result = color.hsv_ref_or("Error: Not an HSV!");
+//! assert_eq!(Ok((&1, &2, &3)), result);
+//!
+//! let color = Color::FromOutOfSpace;
+//! let result = color.hsv_ref_or("Error: Not an HSV!");
+//! assert_eq!(Err("Error: Not an HSV!"), result);
+//! ```
+//!
+//! *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
+//!
 //! ### `pub fn {variant_name}_or_else<E, F: FnOnce() -> E>(self, f: F) -> Result<(...), E>`
 //! If the enum is of the given variant, returns a [`Result::Ok`] containing the inner variant value. Otherwise, calls `f` to calculate a [`Result::Err`].
 //!
@@ -142,6 +194,32 @@
 //!
 //! let color = Color::FromOutOfSpace;
 //! let result = color.hsv_or_else(|| "This is an expensive error to create.");
+//! assert_eq!(Err("This is an expensive error to create."), result);
+//! ```
+//!
+//! *Note: Available only for tuple-style variants such as Color::RGB(200, 40, 180), or Color::Grey(10)*
+//!
+//! ### `pub fn {variant_name}_ref_or_else<E, F: FnOnce() -> E>(&self, f: F) -> Result<(&...), E>`
+//! If the enum is of the given variant, returns a `Result::Ok` containing a ref to the inner variant value. Otherwise, calls `f` to calculate a `Result::Err`.
+//!
+//! #### Example
+//! ```
+//! # #[derive(variantly::Variantly, Debug, PartialEq)]
+//! # enum Color {
+//! #     RGB(u8, u8, u8),
+//! #     HSV(u8, u8, u8),
+//! #     Grey(u8),
+//! #     FromOutOfSpace,
+//! #     #[variantly(rename = "darkness")]
+//! #     Black,
+//! # }
+//! let color = Color::HSV(1,2,3);
+//!
+//! let result = color.hsv_ref_or_else(|| "This is an expensive error to create.");
+//! assert_eq!(Ok((&1, &2, &3)), result);
+//!
+//! let color = Color::FromOutOfSpace;
+//! let result = color.hsv_ref_or_else(|| "This is an expensive error to create.");
 //! assert_eq!(Err("This is an expensive error to create."), result);
 //! ```
 //!

--- a/tests/derived_ref.rs
+++ b/tests/derived_ref.rs
@@ -1,0 +1,26 @@
+mod helper;
+use helper::{
+    TestEnum,
+    TestEnum::{Int, Unit},
+};
+
+#[test]
+fn single_value_tuple() {
+    // Match
+    assert_eq!(Int(123).int_ref(), Some(&123));
+
+    // Non-Match
+    assert_eq!(Unit.int_ref(), None);
+}
+
+#[test]
+fn multi_value_tuple() {
+    // Match
+    assert_eq!(
+        TestEnum::new_tuple(123).tuple_ref(),
+        Some((&"123".into(), &123))
+    );
+
+    // Non-Match
+    assert_eq!(Unit.tuple_ref(), None);
+}


### PR DESCRIPTION
This adds a new `.ref()` method that is derived for all variants:

`pub fn {variant_name}_ref(&self) -> Option(&...)`

Additionally, adds documentation for this and other recent `ref` related fns.
