### PR TITLE
Feature | Support inline generic bounds

### DIFF
--- a/src/derive.rs
+++ b/src/derive.rs
@@ -64,12 +64,11 @@ pub fn derive_variantly_fns(item_enum: ItemEnum) -> Result<TokenStream> {
         });
     });
 
-    let generics = &item_enum.generics;
-    let where_clause = &generics.where_clause;
+    let (impl_generics, type_generics, where_clause) = &item_enum.generics.split_for_impl();
 
     // Declare the actual impl block & iterate over all fns.
     let output: TokenStream = quote! {
-        impl#generics #enum_name#generics #where_clause {
+        impl#impl_generics #enum_name#type_generics #where_clause {
             #(#functions)*
         }
     }

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -4,17 +4,18 @@ use variantly::Variantly;
 
 /// Validate that complex enum variants can validly expand.
 #[derive(Variantly)]
-pub enum ComplexEnum<'a, A, B>
+pub enum ComplexEnum<'a, A, B, C: 'a + Default + core::convert::From<u8>>
 where
     B: Fn() -> String,
 {
     One((((), ()), ()), ((), ())),
     Two(A, B),
-    Three(&'a ComplexEnum<'a, A, B>),
+    Three(&'a ComplexEnum<'a, A, B, C>),
     Four {
-        first: &'a ComplexEnum<'a, String, B>,
+        first: &'a ComplexEnum<'a, String, B, C>,
         second: &'static str,
     },
+    Five(C),
 }
 
 #[derive(Variantly, Clone)]


### PR DESCRIPTION
## The issue

Inlined generic arguments combined with `#[derive(variantly::Variantly)]' would cause strange compile errors:

```rust
#[derive(variantly::Variantly)]
enum A<B: SomeTrait>{ ... }; // error[E0658]: associated type bounds are unstable
```

## The fix 

We use the helper function from the `syn` crate for splitting generics for use in procedural derive macros 😊.